### PR TITLE
Allow for additional parameters to be passed to Stripe_Charge::create()

### DIFF
--- a/Controller/Component/StripeComponent.php
+++ b/Controller/Component/StripeComponent.php
@@ -135,12 +135,29 @@ class StripeComponent extends Component {
 		Stripe::setApiKey($this->key);
 		$error = null;
 
-		$chargeData = array(
-			'amount' => $data['amount'],
-			'currency' => $this->currency,
-			'description' => $data['description'],
-			'capture' => $data['capture']
+		$chargeData = array();
+		$validParams = array(
+			'amount',
+			'currency',
+			'customer',
+			'card',
+			'description',
+			'metadata',
+			'capture',
+			'statement_descriptor',
+			'receipt_email',
+			'application_fee',
+			'shipping'
 		);
+		foreach ($validParams as $param) {
+			if (isset($data[$param])) {
+				$chargeData[$param] = $data[$param];
+			}
+		}
+
+		if (! isset($chargeData['currency'])) {
+			$chargeData['currency'] = $this->currency;
+		}
 
 		if (isset($data['stripeToken'])) {
 			$chargeData['card'] = $data['stripeToken'];


### PR DESCRIPTION
I noticed that when I set parameters like `receipt_email` and `statement_descriptor` for charges, they weren't actually being sent along with charge data. I dug and saw that only the parameters `amount`, `description`, and `capture` were acknowledged and the rest were ignored.

I pulled the list of valid parameters from [the API docs](https://stripe.com/docs/api#create_charge) and added some code that would pass along any valid parameter to `Stripe_Charge::create()`. I tested this on a production site and it appears to be working as intended.