### PR TITLE
Dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
       "php": ">=5.3.0",
       "ext-curl": "*",
       "composer/installers": "*",
-      "stripe/stripe-php": "1.17.2"
+      "stripe/stripe-php": "2.1.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
       "php": ">=5.3.0",
       "ext-curl": "*",
       "composer/installers": "*",
-      "stripe/stripe-php": "2.1.*"
+      "stripe/stripe-php": "1.18.*"
     }
 }


### PR DESCRIPTION
The 2.x Stripe PHP library **is not** readily compatible with this plugin, so updating to 1.18.x.